### PR TITLE
update for dappnode

### DIFF
--- a/docs/hopr-documentation/versioned_docs/version-v1.92/node/using-dappnode.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.92/node/using-dappnode.md
@@ -3,29 +3,19 @@ id: using-dappnode
 title: Using Dappnode
 ---
 
-To set up your DAppNode, follow the instructions that came with the box. Then, just install the HOPR client and you can start using your node right away!
+To set up your Dappnode, follow the instructions that came with the box. Then, just install the HOPR client and you can start using your node right away!
 
 ## Installing the HOPR Client: 1.92.8 (Monte Rosa)
 
-While connected to your Dappnode's network or via a VPN, go to the following [link](http://my.dappnode/#/installer/%2Fipfs%2FQmakbsW3DyfYmP4dtv7QxABh4hh1o3BNWssuGMfGFDvp5j). Just click the install button and wait until the download completes.
+While connected to your Dappnode's network or via a VPN, go to the following [link](http://my.dappnode/#/installer/hopr.public.dappnode.eth). Just click the install button and wait until the install completes.
 
-If you are unable to use the link above, search for this hash in the Dappnode DappStore:
+**OR Install From the DAppStore**
 
 (**1**) Open the DAppStore using the sidebar to the left.
 
-![DappStore](/img/node/DappStore-NR-1.png)
+<img width="1604" alt="Screenshot 2023-03-17 at 1 27 33 AM" src="https://user-images.githubusercontent.com/4649787/225830875-ed154ab1-0e90-45d4-b3ca-7ace73337aeb.png">
 
-(**2**) Enable public repository by clicking on the toggle icon. When the popup opens up, please select: "I understand, take me to the public repo"
-
-(**3**) Search for the HOPR package using this hash:
-
-```
-/ipfs/QmakbsW3DyfYmP4dtv7QxABh4hh1o3BNWssuGMfGFDvp5j
-```
-
-(**4**) Under the Install / Update button, click on Advanced Options and enable "Bypass only signed safe restriction"
-
-(**5**) Click on the Install / Update button
+(**2**) Select the Hopr Package in the Red Box, and click install.
 
 P.S Sometimes, after trying to Install or Update, it will give you an error. Just re-install or update the package if this happens.
 
@@ -45,7 +35,7 @@ Otherwise, the installation process is complete! You can proceed to our [hopr-ad
 
 If you have previously installed a node and have the [identity file downloaded](using-hopr-admin#backing-up-your-identity-file), you can use it to restore your old node.
 
-**Note:** For DAppNode, you should download the latest version of HOPR before trying to restore your node.
+**Note:** For Dappnode, you should download the latest version of HOPR before trying to restore your node.
 
 Find HOPR in your packages and navigate to the backup section. From there, all you have to do is click 'Restore' and open your [zipped backup file](using-hopr-admin#backing-up-your-identity-file) when prompted.
 
@@ -70,17 +60,29 @@ Using the downlaoded file either:
 
 ## Using a Custom RPC Endpoint
 
-You can set your own RPC endpoint for HOPR to use. Ideally, you would install an ETH client on your DAppNode and use its local provider. A local provider helps increase decentralisation and is generally good practice, but you can also use any RPC provider of your choice as long as they are on gnosis chain.
+You can set your own RPC endpoint for HOPR to use. Ideally, you would install an Gnosis Chain Stack on your DAppNode and use it as a local provider. A local provider helps increase decentralisation and is generally good practice, but you can also use any 3rd party RPC provider of your choice as long as they are on Gnosis Chain (Formerly xDai).
 
 **Note:** Only RPC providers on Gnosis chain will work with HOPR
 
-### Finding your local endpoint
+### Using a your local endpoint on Dappnode
 
-If you have already installed an ETH client, you can find its RPC endpoint on the package's info page.
+You need to install a full Gnosis Chain stack in order to run a local Gnosis/xDai node to use it as a local endpoint.
 
-![ETH client settings](/img/node/RPC-endpoint-Dappnode.png)
+(**1**) Follow this [Link](http://my.dappnode/#/stakers/gnosis) to select and configure your Gnosis Chain clients. 
 
-The image above shows the RPC endpoint for the GETH client (querying API in the image): `http://ethchain-geth.my.ava.do:8545`. Your endpoint will be different depending on the client you have installed. Otherwise, you can use any non-local RPC provider such as [ankr.](https://www.ankr.com/)
+(**2**) Currently only Nethermind xDai is available as an execution client for Gnosis chain, so select it from the Execution Column (In Red Box)
+
+(**3**) Currently only Lighthouse Gnosis and Teku Gnosis are available as consensus clients for Gnosis chain, so select one of them from their Column and enter an address you have full control over, using checkpoint sync is much faster to get up and running.  (options are in Green Boxes)
+
+(**4**) Finally Click the Apply Button in the Blue Box and The clients will be installed and start syncing.
+
+<img width="1667" alt="Screenshot 2023-03-17 at 1 09 48 AM" src="https://user-images.githubusercontent.com/4649787/225829118-4a608ff9-f6ea-4095-8dc6-1a63e8bdcbca.png">
+
+Because Nethermind xDai is the only supported Gnosis Chain Execution Client currently, once you have installed and synced the Gnosis Chain stack as described above the endpoint for Nethermind xDai, your local endpoint on Dappnode will be `http://nethermind-xdai.dappnode:8545`
+
+### Remote endpoint
+
+Otherwise, you can use any non-local RPC provider such as [ankr.](https://www.ankr.com/)
 
 ### Changing your RPC endpoint
 
@@ -94,4 +96,4 @@ To change your RPC endpoint:
 
 (**3**) Click 'Update' and wait for your node to restart.
 
-All done! Your DAppNode node will now use your specified RPC endpoint.
+All done! Your Dappnode Hopr Node will now use your specified RPC endpoint.


### PR DESCRIPTION
replaced very outdated instructions and irrelevant instructions, and bad copy pastes relating to the fork of Dappnode, Avado.